### PR TITLE
Add `is_root_span`

### DIFF
--- a/lib/OpenTracing/Role/Span.pm
+++ b/lib/OpenTracing/Role/Span.pm
@@ -227,6 +227,8 @@ sub get_parent_span_id {
 
 
 
+sub is_root_span { ! shift->get_parent_span_id() }
+
 # _set_context
 #
 # you really shouldn't change the context yourself, only on instantiation

--- a/lib/OpenTracing/Role/Span.pod
+++ b/lib/OpenTracing/Role/Span.pod
@@ -320,6 +320,32 @@ I<none>
 
 
 
+=head2 C<is_root_span>
+
+Returns 'true' if this is the root span, that is, if there is no parent span id.
+
+=over
+
+=item Parameter(s)
+
+=over
+
+I<none>
+
+=back
+
+=item Returns
+
+=over
+
+=item C<Boolean>, according to perl
+
+=back
+
+=back
+
+
+
 =head2 C<duration>
 
 The time (in seconds) between start and finish. This will C<croak> when either

--- a/t/Span/11_is_root_span.t
+++ b/t/Span/11_is_root_span.t
@@ -1,0 +1,112 @@
+use Test::Most;
+
+
+$ENV{EXTENDED_TESTING} = 1 unless exists $ENV{EXTENDED_TESTING};
+#
+# This breaks if it would be set to 0 externally, so, don't do that!!!
+
+
+
+subtest "Test without 'child_of'" => sub {
+    
+    my $this_context = MyStub::SpanContext
+        ->new
+        ->with_span_id('1e43f');
+    
+    my $test_span;
+    
+    lives_ok {
+        $test_span = MyStub::Span->new(
+            operation_name => 'child_of_none',
+            context        => $this_context,
+        );
+    } "Created a new span, without a 'child_of'"
+    
+    or return;
+    
+    ok $test_span->is_root_span,
+        "... and is a root span";
+};
+
+
+
+subtest "Test with 'child_of' a 'SpanContext'" => sub {
+    
+    my $some_context = MyStub::SpanContext
+        ->new
+        ->with_span_id('1e43f');
+    
+    my $this_context = $some_context
+        ->new_clone
+        ->with_span_id('45ed0');
+    
+    my $test_span;
+    
+    lives_ok {
+        $test_span = MyStub::Span->new(
+            operation_name => 'child_of_span_context',
+            context        => $this_context,
+            child_of       => $some_context,
+        );
+    } "Created a new span, with a 'child_of' 'span_contex'"
+    
+    or return;
+    
+    ok !$test_span->is_root_span,
+        "... and is NOT a root span";
+};
+
+
+
+subtest "Test with 'child_of' a 'Span'" => sub {
+    
+    my $some_context = MyStub::SpanContext->new
+        ->with_span_id('1e43f');
+    
+    my $some_span = MyStub::Span->new(
+        operation_name => 'some_span', 
+        context        => $some_context
+    );
+    
+    my $this_context = $some_span
+        ->get_context
+        ->new_clone
+        ->with_span_id('45ed0');
+    
+    my $test_span;
+    
+    lives_ok {
+        $test_span = MyStub::Span->new(
+            operation_name => 'child_of_span',
+            context        => $this_context,
+            child_of       => $some_span,
+        );
+    } "Created a new span, with a 'child_of' 'span_contex'"
+    
+    or return;
+    
+    ok !$test_span->is_root_span,
+        "... and is NOT a root span";
+};
+
+
+
+done_testing();
+
+
+
+package MyStub::Span;
+use Moo;
+
+BEGIN { with 'OpenTracing::Role::Span' }
+
+
+
+package MyStub::SpanContext;
+use Moo;
+
+BEGIN { with 'OpenTracing::Role::SpanContext' }
+
+
+
+1;


### PR DESCRIPTION
This is just a more descriptive way to check if this is a root span.

This is typically used when a Tracer is  checking if it needs to flush it's buffer once the 'root span' is being closed and send to it's client.